### PR TITLE
gofmt everything

### DIFF
--- a/src/openid/discover.go
+++ b/src/openid/discover.go
@@ -19,42 +19,42 @@ package openid
 // used as both the Claimed Identifier and the OP-Local Identifier
 // when an OP Identifier is entered.
 func Discover(id string) (opEndpoint, opLocalId, claimedId string, err error) {
-  return discover(id, urlGetter)
+	return discover(id, urlGetter)
 }
 
 var identifier_select = "http://specs.openid.net/auth/2.0/identifier_select"
 
 // Same as the above public Discover function, but test-friendly.
 func discover(id string, getter httpGetter) (opEndpoint, opLocalId, claimedId string, err error) {
-  // From OpenID specs, 7.3: Discovery.
+	// From OpenID specs, 7.3: Discovery.
 
-  // If the identifier is an XRI, [XRI_Resolution_2.0] will yield an
-  // XRDS document that contains the necessary information. It
-  // should also be noted that Relying Parties can take advantage of
-  // XRI Proxy Resolvers, such as the one provided by XDI.org at
-  // http://www.xri.net. This will remove the need for the RPs to
-  // perform XRI Resolution locally.
+	// If the identifier is an XRI, [XRI_Resolution_2.0] will yield an
+	// XRDS document that contains the necessary information. It
+	// should also be noted that Relying Parties can take advantage of
+	// XRI Proxy Resolvers, such as the one provided by XDI.org at
+	// http://www.xri.net. This will remove the need for the RPs to
+	// perform XRI Resolution locally.
 
-  // XRI not supported.
+	// XRI not supported.
 
-  // If it is a URL, the Yadis protocol [Yadis] SHALL be first
-  // attempted. If it succeeds, the result is again an XRDS
-  // document.
-  if opEndpoint, opLocalId, err = yadisDiscovery(id, getter); err != nil {
-    // If the Yadis protocol fails and no valid XRDS document is
-    // retrieved, or no Service Elements are found in the XRDS
-    // document, the URL is retrieved and HTML-Based discovery SHALL be
-    // attempted.
-    opEndpoint, opLocalId, claimedId, err = htmlDiscovery(id, getter)
-  }
+	// If it is a URL, the Yadis protocol [Yadis] SHALL be first
+	// attempted. If it succeeds, the result is again an XRDS
+	// document.
+	if opEndpoint, opLocalId, err = yadisDiscovery(id, getter); err != nil {
+		// If the Yadis protocol fails and no valid XRDS document is
+		// retrieved, or no Service Elements are found in the XRDS
+		// document, the URL is retrieved and HTML-Based discovery SHALL be
+		// attempted.
+		opEndpoint, opLocalId, claimedId, err = htmlDiscovery(id, getter)
+	}
 
-  if err != nil {
-    return "", "", "", err
-  }
+	if err != nil {
+		return "", "", "", err
+	}
 
-  if claimedId == "" {
-    claimedId = identifier_select
-    opLocalId = identifier_select
-  }
-  return
+	if claimedId == "" {
+		claimedId = identifier_select
+		opLocalId = identifier_select
+	}
+	return
 }

--- a/src/openid/discover_test.go
+++ b/src/openid/discover_test.go
@@ -1,51 +1,51 @@
 package openid
 
 import (
-  "testing"
+	"testing"
 )
 
 func TestDiscoverWithYadis(t *testing.T) {
-  // They all redirect to the same XRDS document
-  expectOpIdErr(t, "http://example.com/xrds",
-    "foo", identifier_select, identifier_select, false)
-  expectOpIdErr(t, "http://example.com/xrds-loc",
-    "foo", identifier_select, identifier_select, false)
-  expectOpIdErr(t, "http://example.com/xrds-meta",
-    "foo", identifier_select, identifier_select, false)
+	// They all redirect to the same XRDS document
+	expectOpIdErr(t, "http://example.com/xrds",
+		"foo", identifier_select, identifier_select, false)
+	expectOpIdErr(t, "http://example.com/xrds-loc",
+		"foo", identifier_select, identifier_select, false)
+	expectOpIdErr(t, "http://example.com/xrds-meta",
+		"foo", identifier_select, identifier_select, false)
 }
 
 func TestDiscoverWithHtml(t *testing.T) {
-  // Yadis discovery will fail, and fall back to html.
-  expectOpIdErr(t, "http://example.com/html",
-    "example.com/openid", "bar-name", "http://example.com/html",
-    false)
-  // The first url redirects to a different URL. The redirected-to
-  // url should be used as claimedID.
-  expectOpIdErr(t, "http://example.com/html-redirect",
-    "example.com/openid", "bar-name", "http://example.com/html",
-    false)
+	// Yadis discovery will fail, and fall back to html.
+	expectOpIdErr(t, "http://example.com/html",
+		"example.com/openid", "bar-name", "http://example.com/html",
+		false)
+	// The first url redirects to a different URL. The redirected-to
+	// url should be used as claimedID.
+	expectOpIdErr(t, "http://example.com/html-redirect",
+		"example.com/openid", "bar-name", "http://example.com/html",
+		false)
 }
 
 func TestDiscoverBadUrl(t *testing.T) {
-  expectOpIdErr(t, "http://example.com/404", "", "", "", true)
+	expectOpIdErr(t, "http://example.com/404", "", "", "", true)
 }
 
 func expectOpIdErr(t *testing.T, uri, exOpEndpoint, exOpLocalId, exClaimedId string, exErr bool) {
-  opEndpoint, opLocalId, claimedId, err := discover(uri, testGetter)
-  if (err != nil) != exErr {
-    t.Errorf("Unexpected error: '%s'", err)
-  } else {
-    if opEndpoint != exOpEndpoint {
-      t.Errorf("Extracted Endpoint does not match: Exepect %s, Got %s",
-        exOpEndpoint, opEndpoint)
-    }
-    if opLocalId != exOpLocalId {
-      t.Errorf("Extracted LocalId does not match: Exepect %s, Got %s",
-        exOpLocalId, opLocalId)
-    }
-    if claimedId != exClaimedId {
-      t.Errorf("Extracted ClaimedID does not match: Exepect %s, Got %s",
-        exClaimedId, claimedId)
-    }
-  }
+	opEndpoint, opLocalId, claimedId, err := discover(uri, testGetter)
+	if (err != nil) != exErr {
+		t.Errorf("Unexpected error: '%s'", err)
+	} else {
+		if opEndpoint != exOpEndpoint {
+			t.Errorf("Extracted Endpoint does not match: Exepect %s, Got %s",
+				exOpEndpoint, opEndpoint)
+		}
+		if opLocalId != exOpLocalId {
+			t.Errorf("Extracted LocalId does not match: Exepect %s, Got %s",
+				exOpLocalId, opLocalId)
+		}
+		if claimedId != exClaimedId {
+			t.Errorf("Extracted ClaimedID does not match: Exepect %s, Got %s",
+				exClaimedId, claimedId)
+		}
+	}
 }

--- a/src/openid/discovery_cache.go
+++ b/src/openid/discovery_cache.go
@@ -1,52 +1,52 @@
 package openid
 
 type DiscoveredInfo interface {
-  OpEndpoint() string
-  OpLocalId() string
-  ClaimedId() string
-  // ProtocolVersion: it's always openId 2.
+	OpEndpoint() string
+	OpLocalId() string
+	ClaimedId() string
+	// ProtocolVersion: it's always openId 2.
 }
 
 type DiscoveryCache interface {
-  Put(id string, info DiscoveredInfo)
-  // Return a discovered info, or nil.
-  Get(id string) DiscoveredInfo
+	Put(id string, info DiscoveredInfo)
+	// Return a discovered info, or nil.
+	Get(id string) DiscoveredInfo
 }
 
 type SimpleDiscoveredInfo struct {
-  opEndpoint string
-  opLocalId  string
-  claimedId  string
+	opEndpoint string
+	opLocalId  string
+	claimedId  string
 }
 
 func (s *SimpleDiscoveredInfo) OpEndpoint() string {
-  return s.opEndpoint
+	return s.opEndpoint
 }
 
 func (s *SimpleDiscoveredInfo) OpLocalId() string {
-  return s.opLocalId
+	return s.opLocalId
 }
 
 func (s *SimpleDiscoveredInfo) ClaimedId() string {
-  return s.claimedId
+	return s.claimedId
 }
 
 type SimpleDiscoveryCache map[string]DiscoveredInfo
 
 func (s SimpleDiscoveryCache) Put(id string, info DiscoveredInfo) {
-  s[id] = info
+	s[id] = info
 }
 
 func (s SimpleDiscoveryCache) Get(id string) DiscoveredInfo {
-  if info, has := s[id]; has {
-    return info
-  }
-  return nil
+	if info, has := s[id]; has {
+		return info
+	}
+	return nil
 }
 
 func compareDiscoveredInfo(a DiscoveredInfo, opEndpoint, opLocalId, claimedId string) bool {
-  return a != nil &&
-    a.OpEndpoint() == opEndpoint &&
-    a.OpLocalId() == opLocalId &&
-    a.ClaimedId() == claimedId
+	return a != nil &&
+		a.OpEndpoint() == opEndpoint &&
+		a.OpLocalId() == opLocalId &&
+		a.ClaimedId() == claimedId
 }

--- a/src/openid/fake_getter_test.go
+++ b/src/openid/fake_getter_test.go
@@ -1,53 +1,53 @@
 package openid
 
 import (
-  "bufio"
-  "bytes"
-  "errors"
-  "net/http"
-  "net/url"
+	"bufio"
+	"bytes"
+	"errors"
+	"net/http"
+	"net/url"
 )
 
 type fakeGetter struct {
-  urls      map[string]string
-  redirects map[string]string
+	urls      map[string]string
+	redirects map[string]string
 }
 
 var testGetter = &fakeGetter{
-  make(map[string]string), make(map[string]string)}
+	make(map[string]string), make(map[string]string)}
 
 func (f *fakeGetter) Get(uri string, headers map[string]string) (resp *http.Response, err error) {
-  key := uri
-  for k, v := range headers {
-    key += "#" + k + "#" + v
-  }
+	key := uri
+	for k, v := range headers {
+		key += "#" + k + "#" + v
+	}
 
-  if doc, ok := f.urls[key]; ok {
-    request, err := http.NewRequest("GET", uri, nil)
-    if err != nil {
-      return nil, err
-    }
+	if doc, ok := f.urls[key]; ok {
+		request, err := http.NewRequest("GET", uri, nil)
+		if err != nil {
+			return nil, err
+		}
 
-    return http.ReadResponse(bufio.NewReader(
-      bytes.NewBuffer([]byte(doc))), request)
-  }
-  if uri, ok := f.redirects[key]; ok {
-    return f.Get(uri, headers)
-  }
+		return http.ReadResponse(bufio.NewReader(
+			bytes.NewBuffer([]byte(doc))), request)
+	}
+	if uri, ok := f.redirects[key]; ok {
+		return f.Get(uri, headers)
+	}
 
-  return nil, errors.New("404 not found")
+	return nil, errors.New("404 not found")
 }
 
 func (f *fakeGetter) Post(uri string, form url.Values) (resp *http.Response, err error) {
-  return f.Get("POST@"+uri, nil)
+	return f.Get("POST@"+uri, nil)
 }
 
 func init() {
-  // Prepare (http#header#header-val --> http response) pairs.
+	// Prepare (http#header#header-val --> http response) pairs.
 
-  // === For Yadis discovery ==================================
-  // Directly reffers a valid XRDS document
-  testGetter.urls["http://example.com/xrds#Accept#application/xrds+xml"] = `HTTP/1.0 200 OK
+	// === For Yadis discovery ==================================
+	// Directly reffers a valid XRDS document
+	testGetter.urls["http://example.com/xrds#Accept#application/xrds+xml"] = `HTTP/1.0 200 OK
 Content-Type: application/xrds+xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
@@ -62,28 +62,28 @@ xmlns:openid="http://openid.net/xmlns/1.0">
   </XRD>
 </xrds:XRDS>`
 
-  // Uses a X-XRDS-Location header to redirect to the valid XRDS document.
-  testGetter.urls["http://example.com/xrds-loc#Accept#application/xrds+xml"] = `HTTP/1.0 200 OK
+	// Uses a X-XRDS-Location header to redirect to the valid XRDS document.
+	testGetter.urls["http://example.com/xrds-loc#Accept#application/xrds+xml"] = `HTTP/1.0 200 OK
 X-XRDS-Location: http://example.com/xrds
 
 nothing interesting here`
 
-  // Html document, with meta tag X-XRDS-Location. Points to the
-  // previous valid XRDS document.
-  testGetter.urls["http://example.com/xrds-meta#Accept#application/xrds+xml"] = `HTTP/1.0 200 OK
+	// Html document, with meta tag X-XRDS-Location. Points to the
+	// previous valid XRDS document.
+	testGetter.urls["http://example.com/xrds-meta#Accept#application/xrds+xml"] = `HTTP/1.0 200 OK
 Content-Type: text/html
 
 <html>
 <head>
 <meta http-equiv="X-XRDS-Location" content="http://example.com/xrds">`
 
-  // === For HTML discovery ===================================
-  testGetter.urls["http://example.com/html"] = `HTTP/1.0 200 OK
+	// === For HTML discovery ===================================
+	testGetter.urls["http://example.com/html"] = `HTTP/1.0 200 OK
 
 <html>
 <head>
 <link rel="openid2.provider" href="example.com/openid">
 <link rel="openid2.local_id" href="bar-name">`
 
-  testGetter.redirects["http://example.com/html-redirect"] = "http://example.com/html"
+	testGetter.redirects["http://example.com/html-redirect"] = "http://example.com/html"
 }

--- a/src/openid/getter.go
+++ b/src/openid/getter.go
@@ -1,14 +1,14 @@
 package openid
 
 import (
-  "net/http"
-  "net/url"
+	"net/http"
+	"net/url"
 )
 
 // Interface that simplifies testing.
 type httpGetter interface {
-  Get(uri string, headers map[string]string) (resp *http.Response, err error)
-  Post(uri string, form url.Values) (resp *http.Response, err error)
+	Get(uri string, headers map[string]string) (resp *http.Response, err error)
+	Post(uri string, form url.Values) (resp *http.Response, err error)
 }
 
 type defaultGetter struct{}
@@ -16,17 +16,17 @@ type defaultGetter struct{}
 var urlGetter = &defaultGetter{}
 
 func (*defaultGetter) Get(uri string, headers map[string]string) (resp *http.Response, err error) {
-  request, err := http.NewRequest("GET", uri, nil)
-  if err != nil {
-    return
-  }
-  for h, v := range headers {
-    request.Header.Add(h, v)
-  }
-  client := &http.Client{}
-  return client.Do(request)
+	request, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	for h, v := range headers {
+		request.Header.Add(h, v)
+	}
+	client := &http.Client{}
+	return client.Do(request)
 }
 
 func (*defaultGetter) Post(uri string, form url.Values) (resp *http.Response, err error) {
-  return http.PostForm(uri, form)
+	return http.PostForm(uri, form)
 }

--- a/src/openid/html_discovery.go
+++ b/src/openid/html_discovery.go
@@ -1,74 +1,75 @@
 package openid
 
 import (
-  "errors"
-  "io"
-  "code.google.com/p/go.net/html"
+	"errors"
+	"io"
+
+	"code.google.com/p/go.net/html"
 )
 
 func htmlDiscovery(id string, getter httpGetter) (opEndpoint, opLocalId, claimedId string, err error) {
-  resp, err := getter.Get(id, nil)
-  if err != nil {
-    return "", "", "", err
-  }
-  opEndpoint, opLocalId, err = findProviderFromHeadLink(resp.Body)
-  return opEndpoint, opLocalId, resp.Request.URL.String(), err
+	resp, err := getter.Get(id, nil)
+	if err != nil {
+		return "", "", "", err
+	}
+	opEndpoint, opLocalId, err = findProviderFromHeadLink(resp.Body)
+	return opEndpoint, opLocalId, resp.Request.URL.String(), err
 }
 
 func findProviderFromHeadLink(input io.Reader) (opEndpoint, opLocalId string, err error) {
-  tokenizer := html.NewTokenizer(input)
-  inHead := false
-  for {
-    tt := tokenizer.Next()
-    switch tt {
-    case html.ErrorToken:
-      // Even if the document is malformed after we found a
-      // valid <link> tag, ignore and let's be happy with our
-      // openid2.provider and potentially openid2.local_id as well.
-      if len(opEndpoint) > 0 {
-        return
-      }
-      return "", "", tokenizer.Err()
-    case html.StartTagToken, html.EndTagToken:
-      tk := tokenizer.Token()
-      if tk.Data == "head" {
-        if tt == html.StartTagToken {
-          inHead = true
-        } else {
-          if len(opEndpoint) > 0 {
-            return
-          }
-          return "", "", errors.New(
-            "LINK with rel=openid2.provider not found")
-        }
-      } else if inHead && tk.Data == "link" {
-        provider := false
-        localId := false
-        href := ""
-        for _, attr := range tk.Attr {
-          if attr.Key == "rel" {
-            if attr.Val == "openid2.provider" {
-              provider = true
-            } else if attr.Val == "openid2.local_id" {
-              localId = true
-            }
-          } else if attr.Key == "href" {
-            href = attr.Val
-          }
-        }
-        if provider && !localId && len(href) > 0 {
-          opEndpoint = href
-        } else if !provider && localId && len(href) > 0 {
-          opLocalId = href
-        }
-      }
-    }
-  }
-  // At this point we should probably have returned either from
-  // a closing </head> or a tokenizer error (no </head> found).
-  // But just in case.
-  if len(opEndpoint) > 0 {
-    return
-  }
-  return "", "", errors.New("LINK rel=openid2.provider not found")
+	tokenizer := html.NewTokenizer(input)
+	inHead := false
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			// Even if the document is malformed after we found a
+			// valid <link> tag, ignore and let's be happy with our
+			// openid2.provider and potentially openid2.local_id as well.
+			if len(opEndpoint) > 0 {
+				return
+			}
+			return "", "", tokenizer.Err()
+		case html.StartTagToken, html.EndTagToken:
+			tk := tokenizer.Token()
+			if tk.Data == "head" {
+				if tt == html.StartTagToken {
+					inHead = true
+				} else {
+					if len(opEndpoint) > 0 {
+						return
+					}
+					return "", "", errors.New(
+						"LINK with rel=openid2.provider not found")
+				}
+			} else if inHead && tk.Data == "link" {
+				provider := false
+				localId := false
+				href := ""
+				for _, attr := range tk.Attr {
+					if attr.Key == "rel" {
+						if attr.Val == "openid2.provider" {
+							provider = true
+						} else if attr.Val == "openid2.local_id" {
+							localId = true
+						}
+					} else if attr.Key == "href" {
+						href = attr.Val
+					}
+				}
+				if provider && !localId && len(href) > 0 {
+					opEndpoint = href
+				} else if !provider && localId && len(href) > 0 {
+					opLocalId = href
+				}
+			}
+		}
+	}
+	// At this point we should probably have returned either from
+	// a closing </head> or a tokenizer error (no </head> found).
+	// But just in case.
+	if len(opEndpoint) > 0 {
+		return
+	}
+	return "", "", errors.New("LINK rel=openid2.provider not found")
 }

--- a/src/openid/html_discovery_test.go
+++ b/src/openid/html_discovery_test.go
@@ -1,17 +1,17 @@
 package openid
 
 import (
-  "bytes"
-  "testing"
+	"bytes"
+	"testing"
 )
 
 func TestFindEndpointFromLink(t *testing.T) {
-  searchLink(t, `
+	searchLink(t, `
       <html>
         <head>
           <link rel="openid2.provider" href="example.com/openid">
       `, "example.com/openid", "", false)
-  searchLink(t, `
+	searchLink(t, `
       <html>
         <head>
           <link rel="openid2.provider" href="foo.com">
@@ -22,13 +22,13 @@ func TestFindEndpointFromLink(t *testing.T) {
 }
 
 func TestNoEndpointFromLink(t *testing.T) {
-  searchLink(t, `
+	searchLink(t, `
       <html>
         <head>
           <link rel="openid2.provider">
       `, "", "", true)
-  // Outside of head.
-  searchLink(t, `
+	// Outside of head.
+	searchLink(t, `
       <html>
         <head></head>
         <link rel="openid2.provider" href="example.com/openid">
@@ -36,18 +36,18 @@ func TestNoEndpointFromLink(t *testing.T) {
 }
 
 func searchLink(t *testing.T, doc, opEndpoint, claimedId string, err bool) {
-  r := bytes.NewReader([]byte(doc))
-  op, id, e := findProviderFromHeadLink(r)
-  if (e != nil) != err {
-    t.Errorf("Unexpected error: '%s'", e)
-  } else if e == nil {
-    if op != opEndpoint {
-      t.Errorf("Found bad endpoint: Expected %s, Got %s",
-        op, opEndpoint)
-    }
-    if id != claimedId {
-      t.Errorf("Found bad id: Expected %s, Got %s",
-        id, claimedId)
-    }
-  }
+	r := bytes.NewReader([]byte(doc))
+	op, id, e := findProviderFromHeadLink(r)
+	if (e != nil) != err {
+		t.Errorf("Unexpected error: '%s'", e)
+	} else if e == nil {
+		if op != opEndpoint {
+			t.Errorf("Found bad endpoint: Expected %s, Got %s",
+				op, opEndpoint)
+		}
+		if id != claimedId {
+			t.Errorf("Found bad id: Expected %s, Got %s",
+				id, claimedId)
+		}
+	}
 }

--- a/src/openid/integration/discovery_test.go
+++ b/src/openid/integration/discovery_test.go
@@ -5,43 +5,43 @@ package integration
 // whatever, they will fail. It's ok though, they are full tests.
 
 import (
-  "testing"
-  . "openid"
+	. "openid"
+	"testing"
 )
 
 func TestGoogleCom(t *testing.T) {
-  expectDiscovery(t, "https://www.google.com/accounts/o8/id",
-      "https://www.google.com/accounts/o8/ud",
-      "http://specs.openid.net/auth/2.0/identifier_select",
-      "http://specs.openid.net/auth/2.0/identifier_select")
+	expectDiscovery(t, "https://www.google.com/accounts/o8/id",
+		"https://www.google.com/accounts/o8/ud",
+		"http://specs.openid.net/auth/2.0/identifier_select",
+		"http://specs.openid.net/auth/2.0/identifier_select")
 }
 
 func TestYahoo(t *testing.T) {
-  expectDiscovery(t, "https://me.yahoo.com",
-      "https://open.login.yahooapis.com/openid/op/auth",
-      "http://specs.openid.net/auth/2.0/identifier_select",
-      "http://specs.openid.net/auth/2.0/identifier_select")
+	expectDiscovery(t, "https://me.yahoo.com",
+		"https://open.login.yahooapis.com/openid/op/auth",
+		"http://specs.openid.net/auth/2.0/identifier_select",
+		"http://specs.openid.net/auth/2.0/identifier_select")
 }
 
 func TestYohcop(t *testing.T) {
-  expectDiscovery(t, "http://yohcop.net",
-      "https://www.google.com/accounts/o8/ud?source=profiles",
-      "http://www.google.com/profiles/yohcop",
-      "http://yohcop.net")
+	expectDiscovery(t, "http://yohcop.net",
+		"https://www.google.com/accounts/o8/ud?source=profiles",
+		"http://www.google.com/profiles/yohcop",
+		"http://yohcop.net")
 }
 
 func expectDiscovery(t *testing.T, uri, expectOp, expectLocalId, expectClaimedId string) {
-  endpoint, localId, claimedId, err := Discover(uri)
-  if err != nil {
-    t.Errorf("Discovery failed")
-  }
-  if endpoint != expectOp {
-    t.Errorf("Unexpected endpoint: %s", endpoint)
-  }
-  if localId != expectLocalId {
-    t.Errorf("Unexpected localId: %s", localId)
-  }
-  if claimedId != expectClaimedId {
-    t.Errorf("Unexpected claimedId: %s", claimedId)
-  }
+	endpoint, localId, claimedId, err := Discover(uri)
+	if err != nil {
+		t.Errorf("Discovery failed")
+	}
+	if endpoint != expectOp {
+		t.Errorf("Unexpected endpoint: %s", endpoint)
+	}
+	if localId != expectLocalId {
+		t.Errorf("Unexpected localId: %s", localId)
+	}
+	if claimedId != expectClaimedId {
+		t.Errorf("Unexpected claimedId: %s", claimedId)
+	}
 }

--- a/src/openid/nonce_store.go
+++ b/src/openid/nonce_store.go
@@ -1,85 +1,85 @@
 package openid
 
 import (
-  "errors"
-  "flag"
-  "fmt"
-  "sync"
-  "time"
+	"errors"
+	"flag"
+	"fmt"
+	"sync"
+	"time"
 )
 
 var max_nonce_age = flag.Duration("openid-max-nonce-age",
-  60*time.Second,
-  "Maximum accepted age for openid nonces. The bigger, the more"+
-    "memory is needed to store used nonces.")
+	60*time.Second,
+	"Maximum accepted age for openid nonces. The bigger, the more"+
+		"memory is needed to store used nonces.")
 
 var nonceStore = &SimpleNonceStore{Store: make(map[string][]*Nonce)}
 
 type NonceStore interface {
-  // Returns nil if accepted, an error otherwise.
-  Accept(endpoint, nonce string) error
+	// Returns nil if accepted, an error otherwise.
+	Accept(endpoint, nonce string) error
 }
 
 type Nonce struct {
-  T time.Time
-  S string
+	T time.Time
+	S string
 }
 
 type SimpleNonceStore struct {
-  Store map[string][]*Nonce
-  mutex sync.Mutex
+	Store map[string][]*Nonce
+	mutex sync.Mutex
 }
 
 func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
-  // Value: A string 255 characters or less in length, that MUST be
-  // unique to this particular successful authentication response.
-  if len(nonce) < 20 || len(nonce) > 256 {
-    return errors.New("Invalid nonce")
-  }
+	// Value: A string 255 characters or less in length, that MUST be
+	// unique to this particular successful authentication response.
+	if len(nonce) < 20 || len(nonce) > 256 {
+		return errors.New("Invalid nonce")
+	}
 
-  // The nonce MUST start with the current time on the server, and MAY
-  // contain additional ASCII characters in the range 33-126 inclusive
-  // (printable non-whitespace characters), as necessary to make each
-  // response unique. The date and time MUST be formatted as specified in
-  // section 5.6 of [RFC3339], with the following restrictions:
+	// The nonce MUST start with the current time on the server, and MAY
+	// contain additional ASCII characters in the range 33-126 inclusive
+	// (printable non-whitespace characters), as necessary to make each
+	// response unique. The date and time MUST be formatted as specified in
+	// section 5.6 of [RFC3339], with the following restrictions:
 
-  // All times must be in the UTC timezone, indicated with a "Z".  No
-  // fractional seconds are allowed For example:
-  // 2005-05-15T17:11:51ZUNIQUE
-  ts, err := time.Parse(time.RFC3339, nonce[0:20])
-  if err != nil {
-    return err
-  }
-  now := time.Now()
-  diff := now.Sub(ts)
-  if diff > *max_nonce_age {
-    return fmt.Errorf("Nonce too old: %ds", diff.Seconds())
-  }
+	// All times must be in the UTC timezone, indicated with a "Z".  No
+	// fractional seconds are allowed For example:
+	// 2005-05-15T17:11:51ZUNIQUE
+	ts, err := time.Parse(time.RFC3339, nonce[0:20])
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	diff := now.Sub(ts)
+	if diff > *max_nonce_age {
+		return fmt.Errorf("Nonce too old: %ds", diff.Seconds())
+	}
 
-  s := nonce[20:]
+	s := nonce[20:]
 
-  // Meh.. now we have to use a mutex, to protect that map from
-  // concurrent access. Could put a go routine in charge of it
-  // though.
-  d.mutex.Lock()
-  defer d.mutex.Unlock()
+	// Meh.. now we have to use a mutex, to protect that map from
+	// concurrent access. Could put a go routine in charge of it
+	// though.
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-  if nonces, hasOp := d.Store[endpoint]; hasOp {
-    // Delete old nonces while we are at it.
-    newNonces := []*Nonce{}
-    for _, n := range nonces {
-      if n.T == ts && n.S == s {
-        // If return early, just ignore the filtered list
-        // we have been building so far...
-        return errors.New("Nonce already used")
-      }
-      if now.Sub(n.T) < *max_nonce_age {
-        newNonces = append(newNonces, n)
-      }
-    }
-    d.Store[endpoint] = newNonces
-  } else {
-    d.Store[endpoint] = []*Nonce{{ts, s}}
-  }
-  return nil
+	if nonces, hasOp := d.Store[endpoint]; hasOp {
+		// Delete old nonces while we are at it.
+		newNonces := []*Nonce{}
+		for _, n := range nonces {
+			if n.T == ts && n.S == s {
+				// If return early, just ignore the filtered list
+				// we have been building so far...
+				return errors.New("Nonce already used")
+			}
+			if now.Sub(n.T) < *max_nonce_age {
+				newNonces = append(newNonces, n)
+			}
+		}
+		d.Store[endpoint] = newNonces
+	} else {
+		d.Store[endpoint] = []*Nonce{{ts, s}}
+	}
+	return nil
 }

--- a/src/openid/nonce_store_test.go
+++ b/src/openid/nonce_store_test.go
@@ -1,44 +1,44 @@
 package openid
 
 import (
-  "testing"
-  "time"
+	"testing"
+	"time"
 )
 
 func TestDefaultNonceStore(t *testing.T) {
-  *max_nonce_age = 60 * time.Second
-  now := time.Now().UTC()
-  // 30 seconds ago
-  now30s := now.Add(-30 * time.Second)
-  // 2 minutes ago
-  now2m := now.Add(-2 * time.Minute)
+	*max_nonce_age = 60 * time.Second
+	now := time.Now().UTC()
+	// 30 seconds ago
+	now30s := now.Add(-30 * time.Second)
+	// 2 minutes ago
+	now2m := now.Add(-2 * time.Minute)
 
-  now30sStr := now30s.Format(time.RFC3339)
-  now2mStr := now2m.Format(time.RFC3339)
+	now30sStr := now30s.Format(time.RFC3339)
+	now2mStr := now2m.Format(time.RFC3339)
 
-  ns := &SimpleNonceStore{store: make(map[string][]*Nonce)}
-  reject(t, ns, "1", "foo")                        // invalid nonce
-  reject(t, ns, "1", "fooBarBazLongerThan20Chars") // invalid nonce
+	ns := &SimpleNonceStore{store: make(map[string][]*Nonce)}
+	reject(t, ns, "1", "foo")                        // invalid nonce
+	reject(t, ns, "1", "fooBarBazLongerThan20Chars") // invalid nonce
 
-  accept(t, ns, "1", now30sStr+"asd")
-  reject(t, ns, "1", now30sStr+"asd") // same nonce
-  accept(t, ns, "1", now30sStr+"xxx") // different nonce
-  accept(t, ns, "2", now30sStr+"asd") // different endpoint
+	accept(t, ns, "1", now30sStr+"asd")
+	reject(t, ns, "1", now30sStr+"asd") // same nonce
+	accept(t, ns, "1", now30sStr+"xxx") // different nonce
+	accept(t, ns, "2", now30sStr+"asd") // different endpoint
 
-  reject(t, ns, "1", now2mStr+"old") // too old
-  reject(t, ns, "3", now2mStr+"old") // too old
+	reject(t, ns, "1", now2mStr+"old") // too old
+	reject(t, ns, "3", now2mStr+"old") // too old
 }
 
 func accept(t *testing.T, ns NonceStore, op, nonce string) {
-  e := ns.Accept(op, nonce)
-  if e != nil {
-    t.Errorf("Should accept %s nonce %s", op, nonce)
-  }
+	e := ns.Accept(op, nonce)
+	if e != nil {
+		t.Errorf("Should accept %s nonce %s", op, nonce)
+	}
 }
 
 func reject(t *testing.T, ns NonceStore, op, nonce string) {
-  e := ns.Accept(op, nonce)
-  if e == nil {
-    t.Errorf("Should reject %s nonce %s", op, nonce)
-  }
+	e := ns.Accept(op, nonce)
+	if e == nil {
+		t.Errorf("Should reject %s nonce %s", op, nonce)
+	}
 }

--- a/src/openid/normalizer.go
+++ b/src/openid/normalizer.go
@@ -1,47 +1,47 @@
 package openid
 
 import (
-  "errors"
-  "strings"
+	"errors"
+	"strings"
 )
 
 func Normalize(id string) (string, error) {
-  // 7.2 from openID 2.0 spec.
+	// 7.2 from openID 2.0 spec.
 
-  //If the user's input starts with the "xri://" prefix, it MUST be
-  //stripped off, so that XRIs are used in the canonical form.
-  if strings.HasPrefix(id, "xri://") {
-    id = id[6:]
-    return "", errors.New("XRI identifiers not supported")
-  }
+	//If the user's input starts with the "xri://" prefix, it MUST be
+	//stripped off, so that XRIs are used in the canonical form.
+	if strings.HasPrefix(id, "xri://") {
+		id = id[6:]
+		return "", errors.New("XRI identifiers not supported")
+	}
 
-  // If the first character of the resulting string is an XRI
-  // Global Context Symbol ("=", "@", "+", "$", "!") or "(", as
-  // defined in Section 2.2.1 of [XRI_Syntax_2.0], then the input
-  // SHOULD be treated as an XRI.
-  if s := string(id[0]); s == "=" || s == "@" || s == "+" || s == "$" || s == "!" {
-    return "", errors.New("XRI identifiers not supported")
-  }
+	// If the first character of the resulting string is an XRI
+	// Global Context Symbol ("=", "@", "+", "$", "!") or "(", as
+	// defined in Section 2.2.1 of [XRI_Syntax_2.0], then the input
+	// SHOULD be treated as an XRI.
+	if s := string(id[0]); s == "=" || s == "@" || s == "+" || s == "$" || s == "!" {
+		return "", errors.New("XRI identifiers not supported")
+	}
 
-  // Otherwise, the input SHOULD be treated as an http URL; if it
-  // does not include a "http" or "https" scheme, the Identifier
-  // MUST be prefixed with the string "http://". If the URL
-  // contains a fragment part, it MUST be stripped off together
-  // with the fragment delimiter character "#". See Section 11.5.2 for
-  // more information.
-  if !strings.HasPrefix(id, "http://") && !strings.HasPrefix(id,
-    "https://") {
-    id = "http://" + id
-  }
-  if fragmentIndex := strings.Index(id, "#"); fragmentIndex != -1 {
-    id = id[0:fragmentIndex]
-  }
+	// Otherwise, the input SHOULD be treated as an http URL; if it
+	// does not include a "http" or "https" scheme, the Identifier
+	// MUST be prefixed with the string "http://". If the URL
+	// contains a fragment part, it MUST be stripped off together
+	// with the fragment delimiter character "#". See Section 11.5.2 for
+	// more information.
+	if !strings.HasPrefix(id, "http://") && !strings.HasPrefix(id,
+		"https://") {
+		id = "http://" + id
+	}
+	if fragmentIndex := strings.Index(id, "#"); fragmentIndex != -1 {
+		id = id[0:fragmentIndex]
+	}
 
-  // URL Identifiers MUST then be further normalized by both
-  // following redirects when retrieving their content and finally
-  // applying the rules in Section 6 of [RFC3986] to the final
-  // destination URL. This final URL MUST be noted by the Relying
-  // Party as the Claimed Identifier and be used when requesting
-  // authentication.
-  return id, nil
+	// URL Identifiers MUST then be further normalized by both
+	// following redirects when retrieving their content and finally
+	// applying the rules in Section 6 of [RFC3986] to the final
+	// destination URL. This final URL MUST be noted by the Relying
+	// Party as the Claimed Identifier and be used when requesting
+	// authentication.
+	return id, nil
 }

--- a/src/openid/normalizer_test.go
+++ b/src/openid/normalizer_test.go
@@ -1,35 +1,35 @@
 package openid
 
 import (
-  "testing"
+	"testing"
 )
 
 func TestNormalizeXRI(t *testing.T) {
-  if _, err := Normalize("xri://asdf"); err == nil {
-    t.Errorf("XRI not supported")
-  }
-  if _, err := Normalize("=asdf"); err == nil {
-    t.Errorf("XRI not supported")
-  }
-  if _, err := Normalize("@asdf"); err == nil {
-    t.Errorf("XRI not supported")
-  }
+	if _, err := Normalize("xri://asdf"); err == nil {
+		t.Errorf("XRI not supported")
+	}
+	if _, err := Normalize("=asdf"); err == nil {
+		t.Errorf("XRI not supported")
+	}
+	if _, err := Normalize("@asdf"); err == nil {
+		t.Errorf("XRI not supported")
+	}
 }
 
 func TestNormalizeHttp(t *testing.T) {
-  if n, err := Normalize("foo.com"); err != nil || n != "http://foo.com" {
-    t.Errorf("http:// should be added")
-  }
-  if n, err := Normalize("http://foo.com"); err != nil || n != "http://foo.com" {
-    t.Errorf("valid URL should not be modified")
-  }
-  if n, err := Normalize("https://foo.com"); err != nil || n != "https://foo.com" {
-    t.Errorf("https:// URLs are valid")
-  }
+	if n, err := Normalize("foo.com"); err != nil || n != "http://foo.com" {
+		t.Errorf("http:// should be added")
+	}
+	if n, err := Normalize("http://foo.com"); err != nil || n != "http://foo.com" {
+		t.Errorf("valid URL should not be modified")
+	}
+	if n, err := Normalize("https://foo.com"); err != nil || n != "https://foo.com" {
+		t.Errorf("https:// URLs are valid")
+	}
 }
 
 func TestNormalizeFragment(t *testing.T) {
-  if n, err := Normalize("http://foo.com#bar"); err != nil || n != "http://foo.com" {
-    t.Errorf("URL fragments must be removed")
-  }
+	if n, err := Normalize("http://foo.com#bar"); err != nil || n != "http://foo.com" {
+		t.Errorf("URL fragments must be removed")
+	}
 }

--- a/src/openid/redirect.go
+++ b/src/openid/redirect.go
@@ -1,56 +1,56 @@
 package openid
 
 import (
-  "net/url"
-  "strings"
+	"net/url"
+	"strings"
 )
 
 func RedirectUrl(id, callbackUrl, realm string) (string, error) {
-  return redirectUrl(id, callbackUrl, realm, urlGetter)
+	return redirectUrl(id, callbackUrl, realm, urlGetter)
 }
 
 func redirectUrl(id, callbackUrl, realm string, getter httpGetter) (string, error) {
-  opEndpoint, opLocalId, claimedId, err := discover(id, getter)
-  if err != nil {
-    return "", err
-  }
-  return buildRedirectUrl(opEndpoint, opLocalId, claimedId, callbackUrl, realm)
+	opEndpoint, opLocalId, claimedId, err := discover(id, getter)
+	if err != nil {
+		return "", err
+	}
+	return buildRedirectUrl(opEndpoint, opLocalId, claimedId, callbackUrl, realm)
 }
 
 func buildRedirectUrl(opEndpoint, opLocalId, claimedId, returnTo, realm string) (string, error) {
-  values := make(url.Values)
-  values.Add("openid.ns", "http://specs.openid.net/auth/2.0")
-  values.Add("openid.mode", "checkid_setup")
-  values.Add("openid.return_to", returnTo)
-  values.Add("openid.ns.sreg","http://openid.net/extensions/sreg/1.1")
-  values.Add("openid.pape.preferred_auth_policies","")
-  values.Add("openid.ns.pape","http://specs.openid.net/extensions/pape/1.0")
-  values.Add("openid.ns","http://specs.openid.net/auth/2.0")
-  values.Add("openid.sreg.required","nickname,fullname,email,timezone")
-  values.Add("openid.lp.query_membership","_FAS_ALL_GROUPS_")
-  values.Add("openid.ns.lp","http://ns.launchpad.net/2007/openid-teams")
-  values.Add("openid.cla.query_cla","http://admin.fedoraproject.org/accounts/cla/done")
-  values.Add("openid.ns.cla","http://fedoraproject.org/specs/open_id/cla")
+	values := make(url.Values)
+	values.Add("openid.ns", "http://specs.openid.net/auth/2.0")
+	values.Add("openid.mode", "checkid_setup")
+	values.Add("openid.return_to", returnTo)
+	values.Add("openid.ns.sreg", "http://openid.net/extensions/sreg/1.1")
+	values.Add("openid.pape.preferred_auth_policies", "")
+	values.Add("openid.ns.pape", "http://specs.openid.net/extensions/pape/1.0")
+	values.Add("openid.ns", "http://specs.openid.net/auth/2.0")
+	values.Add("openid.sreg.required", "nickname,fullname,email,timezone")
+	values.Add("openid.lp.query_membership", "_FAS_ALL_GROUPS_")
+	values.Add("openid.ns.lp", "http://ns.launchpad.net/2007/openid-teams")
+	values.Add("openid.cla.query_cla", "http://admin.fedoraproject.org/accounts/cla/done")
+	values.Add("openid.ns.cla", "http://fedoraproject.org/specs/open_id/cla")
 
-  if len(claimedId) > 0 {
-    values.Add("openid.claimed_id", claimedId)
-    if len(opLocalId) > 0 {
-      values.Add("openid.identity", opLocalId)
-    } else {
-      values.Add("openid.identity",
-        "http://specs.openid.net/auth/2.0/identifier_select")
-    }
-  } else {
-    values.Add("openid.identity",
-      "http://specs.openid.net/auth/2.0/identifier_select")
-  }
+	if len(claimedId) > 0 {
+		values.Add("openid.claimed_id", claimedId)
+		if len(opLocalId) > 0 {
+			values.Add("openid.identity", opLocalId)
+		} else {
+			values.Add("openid.identity",
+				"http://specs.openid.net/auth/2.0/identifier_select")
+		}
+	} else {
+		values.Add("openid.identity",
+			"http://specs.openid.net/auth/2.0/identifier_select")
+	}
 
-  if len(realm) > 0 {
-    values.Add("openid.realm", realm)
-  }
+	if len(realm) > 0 {
+		values.Add("openid.realm", realm)
+	}
 
-  if strings.Contains(opEndpoint, "?") {
-    return opEndpoint + "&" + values.Encode(), nil
-  }
-  return opEndpoint + "?" + values.Encode(), nil
+	if strings.Contains(opEndpoint, "?") {
+		return opEndpoint + "&" + values.Encode(), nil
+	}
+	return opEndpoint + "?" + values.Encode(), nil
 }

--- a/src/openid/redirect_test.go
+++ b/src/openid/redirect_test.go
@@ -1,92 +1,92 @@
 package openid
 
 import (
-  "net/url"
-  "testing"
+	"net/url"
+	"testing"
 )
 
 func TestBuildRedirectUrl(t *testing.T) {
-  expectUrl(t, "https://endpoint/a", "opLocalId", "claimedId", "returnTo", "realm",
-    "https://endpoint/a?"+
-      "openid.ns=http://specs.openid.net/auth/2.0"+
-      "&openid.mode=checkid_setup"+
-      "&openid.return_to=returnTo"+
-      "&openid.claimed_id=claimedId"+
-      "&openid.identity=opLocalId"+
-      "&openid.realm=realm")
-  // No realm.
-  expectUrl(t, "https://endpoint/a", "opLocalId", "claimedId", "returnTo", "",
-    "https://endpoint/a?"+
-      "openid.ns=http://specs.openid.net/auth/2.0"+
-      "&openid.mode=checkid_setup"+
-      "&openid.return_to=returnTo"+
-      "&openid.claimed_id=claimedId"+
-      "&openid.identity=opLocalId")
-  // No realm, no claimedId
-  expectUrl(t, "https://endpoint/a", "opLocalId", "", "returnTo", "",
-    "https://endpoint/a?"+
-      "openid.ns=http://specs.openid.net/auth/2.0"+
-      "&openid.mode=checkid_setup"+
-      "&openid.return_to=returnTo"+
-      "&openid.identity="+
-      "http://specs.openid.net/auth/2.0/identifier_select")
+	expectUrl(t, "https://endpoint/a", "opLocalId", "claimedId", "returnTo", "realm",
+		"https://endpoint/a?"+
+			"openid.ns=http://specs.openid.net/auth/2.0"+
+			"&openid.mode=checkid_setup"+
+			"&openid.return_to=returnTo"+
+			"&openid.claimed_id=claimedId"+
+			"&openid.identity=opLocalId"+
+			"&openid.realm=realm")
+	// No realm.
+	expectUrl(t, "https://endpoint/a", "opLocalId", "claimedId", "returnTo", "",
+		"https://endpoint/a?"+
+			"openid.ns=http://specs.openid.net/auth/2.0"+
+			"&openid.mode=checkid_setup"+
+			"&openid.return_to=returnTo"+
+			"&openid.claimed_id=claimedId"+
+			"&openid.identity=opLocalId")
+	// No realm, no claimedId
+	expectUrl(t, "https://endpoint/a", "opLocalId", "", "returnTo", "",
+		"https://endpoint/a?"+
+			"openid.ns=http://specs.openid.net/auth/2.0"+
+			"&openid.mode=checkid_setup"+
+			"&openid.return_to=returnTo"+
+			"&openid.identity="+
+			"http://specs.openid.net/auth/2.0/identifier_select")
 }
 
 func expectUrl(t *testing.T, opEndpoint, opLocalId, claimedId, returnTo, realm, expected string) {
-  url, err := buildRedirectUrl(opEndpoint, opLocalId, claimedId, returnTo, realm)
-  if err != nil {
-    t.Errorf("Unexpected error: %s", err)
-  }
-  compareUrls(t, url, expected)
+	url, err := buildRedirectUrl(opEndpoint, opLocalId, claimedId, returnTo, realm)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	compareUrls(t, url, expected)
 }
 
 func TestRedirectWithDiscovery(t *testing.T) {
-  expected := "foo?" +
-    "openid.ns=http://specs.openid.net/auth/2.0" +
-    "&openid.mode=checkid_setup" +
-    "&openid.return_to=mysite/cb" +
-    "&openid.claimed_id=" +
-    "http://specs.openid.net/auth/2.0/identifier_select" +
-    "&openid.identity=" +
-    "http://specs.openid.net/auth/2.0/identifier_select"
+	expected := "foo?" +
+		"openid.ns=http://specs.openid.net/auth/2.0" +
+		"&openid.mode=checkid_setup" +
+		"&openid.return_to=mysite/cb" +
+		"&openid.claimed_id=" +
+		"http://specs.openid.net/auth/2.0/identifier_select" +
+		"&openid.identity=" +
+		"http://specs.openid.net/auth/2.0/identifier_select"
 
-  // They all redirect to the same XRDS document
-  expectRedirect(t, "http://example.com/xrds",
-    "mysite/cb", "", expected, false)
-  expectRedirect(t, "http://example.com/xrds-loc",
-    "mysite/cb", "", expected, false)
-  expectRedirect(t, "http://example.com/xrds-meta",
-    "mysite/cb", "", expected, false)
+	// They all redirect to the same XRDS document
+	expectRedirect(t, "http://example.com/xrds",
+		"mysite/cb", "", expected, false)
+	expectRedirect(t, "http://example.com/xrds-loc",
+		"mysite/cb", "", expected, false)
+	expectRedirect(t, "http://example.com/xrds-meta",
+		"mysite/cb", "", expected, false)
 }
 
 func expectRedirect(t *testing.T, uri, callback, realm, exRedirect string, exErr bool) {
-  redirect, err := redirectUrl(uri, callback, realm, testGetter)
-  if (err != nil) != exErr {
-    t.Errorf("Unexpected error: '%s'", err)
-    return
-  }
-  compareUrls(t, redirect, exRedirect)
+	redirect, err := redirectUrl(uri, callback, realm, testGetter)
+	if (err != nil) != exErr {
+		t.Errorf("Unexpected error: '%s'", err)
+		return
+	}
+	compareUrls(t, redirect, exRedirect)
 }
 
 func compareUrls(t *testing.T, url1, expected string) {
-  p1, err1 := url.Parse(url1)
-  p2, err2 := url.Parse(expected)
-  if err1 != nil {
-    t.Errorf("Url1 non parsable: %s", err1)
-    return
-  }
-  if err2 != nil {
-    t.Errorf("ExpectedUrl non parsable: %s", err2)
-    return
-  }
-  if p1.Scheme != p2.Scheme ||
-    p1.Host != p2.Host ||
-    p1.Path != p2.Path {
-    t.Errorf("URLs don't match: %s vs %s", url1, expected)
-  }
-  q1, _ := url.ParseQuery(p1.RawQuery)
-  q2, _ := url.ParseQuery(p2.RawQuery)
-  if err := compareQueryParams(q1, q2); err != nil {
-    t.Errorf("URLs query params don't match: %s: %s vs %s", err, url1, expected)
-  }
+	p1, err1 := url.Parse(url1)
+	p2, err2 := url.Parse(expected)
+	if err1 != nil {
+		t.Errorf("Url1 non parsable: %s", err1)
+		return
+	}
+	if err2 != nil {
+		t.Errorf("ExpectedUrl non parsable: %s", err2)
+		return
+	}
+	if p1.Scheme != p2.Scheme ||
+		p1.Host != p2.Host ||
+		p1.Path != p2.Path {
+		t.Errorf("URLs don't match: %s vs %s", url1, expected)
+	}
+	q1, _ := url.ParseQuery(p1.RawQuery)
+	q2, _ := url.ParseQuery(p2.RawQuery)
+	if err := compareQueryParams(q1, q2); err != nil {
+		t.Errorf("URLs query params don't match: %s: %s vs %s", err, url1, expected)
+	}
 }

--- a/src/openid/xrds.go
+++ b/src/openid/xrds.go
@@ -1,80 +1,80 @@
 package openid
 
 import (
-  "encoding/xml"
-  "errors"
-  "strings"
+	"encoding/xml"
+	"errors"
+	"strings"
 )
 
 // TODO: As per 11.2 in openid 2 specs, a service may have multiple
 //       URIs. We don't care for discovery really, but we do care for
 //       verification though.
 type XrdsIdentifier struct {
-  Type     []string `xml:"Type"`
-  Uri      string   `xml:"URI"`
-  LocalId  string   `xml:"LocalID"`
-  Priority int      `xml:"priority,attr"`
+	Type     []string `xml:"Type"`
+	Uri      string   `xml:"URI"`
+	LocalId  string   `xml:"LocalID"`
+	Priority int      `xml:"priority,attr"`
 }
 
 type Xrd struct {
-  Service []*XrdsIdentifier `xml:"Service"`
+	Service []*XrdsIdentifier `xml:"Service"`
 }
 
 type XrdsDocument struct {
-  XMLName xml.Name `xml:"XRDS"`
-  Xrd     *Xrd     `xml:"XRD"`
+	XMLName xml.Name `xml:"XRDS"`
+	Xrd     *Xrd     `xml:"XRD"`
 }
 
 func parseXrds(input []byte) (opEndpoint, opLocalId string, err error) {
-  xrdsDoc := &XrdsDocument{}
-  err = xml.Unmarshal(input, xrdsDoc)
-  if err != nil {
-    return
-  }
+	xrdsDoc := &XrdsDocument{}
+	err = xml.Unmarshal(input, xrdsDoc)
+	if err != nil {
+		return
+	}
 
-  if xrdsDoc.Xrd == nil {
-    return "", "", errors.New("XRDS document missing XRD tag")
-  }
+	if xrdsDoc.Xrd == nil {
+		return "", "", errors.New("XRDS document missing XRD tag")
+	}
 
-  for _, service := range xrdsDoc.Xrd.Service {
-    // 7.3.2.2.  Extracting Authentication Data
-    // Once the Relying Party has obtained an XRDS document, it
-    // MUST first search the document (following the rules
-    // described in [XRI_Resolution_2.0]) for an OP Identifier
-    // Element. If none is found, the RP will search for a Claimed
-    // Identifier Element.
-    if service.hasType("http://specs.openid.net/auth/2.0/server") {
-      // 7.3.2.1.1.  OP Identifier Element
-      // An OP Identifier Element is an <xrd:Service> element with the
-      // following information:
-      // An <xrd:Type> tag whose text content is
-      //     "http://specs.openid.net/auth/2.0/server".
-      // An <xrd:URI> tag whose text content is the OP Endpoint URL
-      opEndpoint = strings.TrimSpace(service.Uri)
-      return
-    } else if service.hasType("http://specs.openid.net/auth/2.0/signon") {
-      // 7.3.2.1.2.  Claimed Identifier Element
-      // A Claimed Identifier Element is an <xrd:Service> element
-      // with the following information:
-      // An <xrd:Type> tag whose text content is
-      //     "http://specs.openid.net/auth/2.0/signon".
-      // An <xrd:URI> tag whose text content is the OP Endpoint
-      //     URL.
-      // An <xrd:LocalID> tag (optional) whose text content is the
-      //     OP-Local Identifier.
-      opEndpoint = strings.TrimSpace(service.Uri)
-      opLocalId = strings.TrimSpace(service.LocalId)
-      return
-    }
-  }
-  return "", "", errors.New("Could not find a compatible service")
+	for _, service := range xrdsDoc.Xrd.Service {
+		// 7.3.2.2.  Extracting Authentication Data
+		// Once the Relying Party has obtained an XRDS document, it
+		// MUST first search the document (following the rules
+		// described in [XRI_Resolution_2.0]) for an OP Identifier
+		// Element. If none is found, the RP will search for a Claimed
+		// Identifier Element.
+		if service.hasType("http://specs.openid.net/auth/2.0/server") {
+			// 7.3.2.1.1.  OP Identifier Element
+			// An OP Identifier Element is an <xrd:Service> element with the
+			// following information:
+			// An <xrd:Type> tag whose text content is
+			//     "http://specs.openid.net/auth/2.0/server".
+			// An <xrd:URI> tag whose text content is the OP Endpoint URL
+			opEndpoint = strings.TrimSpace(service.Uri)
+			return
+		} else if service.hasType("http://specs.openid.net/auth/2.0/signon") {
+			// 7.3.2.1.2.  Claimed Identifier Element
+			// A Claimed Identifier Element is an <xrd:Service> element
+			// with the following information:
+			// An <xrd:Type> tag whose text content is
+			//     "http://specs.openid.net/auth/2.0/signon".
+			// An <xrd:URI> tag whose text content is the OP Endpoint
+			//     URL.
+			// An <xrd:LocalID> tag (optional) whose text content is the
+			//     OP-Local Identifier.
+			opEndpoint = strings.TrimSpace(service.Uri)
+			opLocalId = strings.TrimSpace(service.LocalId)
+			return
+		}
+	}
+	return "", "", errors.New("Could not find a compatible service")
 }
 
 func (xrdsi *XrdsIdentifier) hasType(tpe string) bool {
-  for _, t := range xrdsi.Type {
-    if t == tpe {
-      return true
-    }
-  }
-  return false
+	for _, t := range xrdsi.Type {
+		if t == tpe {
+			return true
+		}
+	}
+	return false
 }

--- a/src/openid/xrds_test.go
+++ b/src/openid/xrds_test.go
@@ -1,11 +1,11 @@
 package openid
 
 import (
-  "testing"
+	"testing"
 )
 
 func TestXrds(t *testing.T) {
-  testExpectOpId(t, []byte(`
+	testExpectOpId(t, []byte(`
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)"
 xmlns:openid="http://openid.net/xmlns/1.0">
@@ -33,7 +33,7 @@ xmlns:openid="http://openid.net/xmlns/1.0">
 </xrds:XRDS>
     `), "foo", "")
 
-  testExpectOpId(t, []byte(`
+	testExpectOpId(t, []byte(`
 <?xml version="1.0" encoding="UTF-8"?>
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)"
 xmlns:openid="http://openid.net/xmlns/1.0">
@@ -46,22 +46,22 @@ xmlns:openid="http://openid.net/xmlns/1.0">
   </XRD>
 </xrds:XRDS>
     `),
-    "https://www.exampleprovider.com/endpoint/",
-    "https://exampleuser.exampleprovider.com/")
+		"https://www.exampleprovider.com/endpoint/",
+		"https://exampleuser.exampleprovider.com/")
 }
 
 func testExpectOpId(t *testing.T, xrds []byte, op, id string) {
-  receivedOp, receivedId, err := parseXrds(xrds)
-  if err != nil {
-    t.Errorf("Got an error parsing XRDS (%s): %s", string(xrds), err)
-  } else {
-    if receivedOp != op {
-      t.Errorf("Extracted OP does not match: Exepect %s, Got %s",
-        op, receivedOp)
-    }
-    if receivedId != id {
-      t.Errorf("Extracted ID does not match: Exepect %s, Got %s",
-        id, receivedId)
-    }
-  }
+	receivedOp, receivedId, err := parseXrds(xrds)
+	if err != nil {
+		t.Errorf("Got an error parsing XRDS (%s): %s", string(xrds), err)
+	} else {
+		if receivedOp != op {
+			t.Errorf("Extracted OP does not match: Exepect %s, Got %s",
+				op, receivedOp)
+		}
+		if receivedId != id {
+			t.Errorf("Extracted ID does not match: Exepect %s, Got %s",
+				id, receivedId)
+		}
+	}
 }

--- a/src/openid/yadis_discovery.go
+++ b/src/openid/yadis_discovery.go
@@ -1,119 +1,120 @@
 package openid
 
 import (
-  "errors"
-  "io"
-  "io/ioutil"
-  "strings"
-  "code.google.com/p/go.net/html"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"code.google.com/p/go.net/html"
 )
 
 var yadisHeaders = map[string]string{
-  "Accept": "application/xrds+xml"}
+	"Accept": "application/xrds+xml"}
 
 func yadisDiscovery(id string, getter httpGetter) (opEndpoint string, opLocalId string, err error) {
-  // Section 6.2.4 of Yadis 1.0 specifications.
-  // The Yadis Protocol is initiated by the Relying Party Agent
-  // with an initial HTTP request using the Yadis URL.
+	// Section 6.2.4 of Yadis 1.0 specifications.
+	// The Yadis Protocol is initiated by the Relying Party Agent
+	// with an initial HTTP request using the Yadis URL.
 
-  // This request MUST be either a GET or a HEAD request.
+	// This request MUST be either a GET or a HEAD request.
 
-  // A GET or HEAD request MAY include an HTTP Accept
-  // request-header (HTTP 14.1) specifying MIME media type,
-  // application/xrds+xml.
-  resp, err := getter.Get(id, yadisHeaders)
-  if err != nil {
-    return "", "", err
-  }
+	// A GET or HEAD request MAY include an HTTP Accept
+	// request-header (HTTP 14.1) specifying MIME media type,
+	// application/xrds+xml.
+	resp, err := getter.Get(id, yadisHeaders)
+	if err != nil {
+		return "", "", err
+	}
 
-  defer resp.Body.Close()
+	defer resp.Body.Close()
 
-  // Section 6.2.5 from Yadis 1.0 spec: Response
+	// Section 6.2.5 from Yadis 1.0 spec: Response
 
-  contentType := resp.Header.Get("Content-Type")
+	contentType := resp.Header.Get("Content-Type")
 
-  // The response MUST be one of:
-  // (see 6.2.6 for precedence)
-  if l := resp.Header.Get("X-XRDS-Location"); l != "" {
-    // 2. HTTP response-headers that include an X-XRDS-Location
-    // response-header, together with a document
-    return getYadisResourceDescriptor(l, getter)
-  } else if strings.Contains(contentType, "text/html") {
-    // 1. An HTML document with a <head> element that includes a
-    // <meta> element with http-equiv attribute, X-XRDS-Location,
+	// The response MUST be one of:
+	// (see 6.2.6 for precedence)
+	if l := resp.Header.Get("X-XRDS-Location"); l != "" {
+		// 2. HTTP response-headers that include an X-XRDS-Location
+		// response-header, together with a document
+		return getYadisResourceDescriptor(l, getter)
+	} else if strings.Contains(contentType, "text/html") {
+		// 1. An HTML document with a <head> element that includes a
+		// <meta> element with http-equiv attribute, X-XRDS-Location,
 
-    if metaContent, err := findMetaXrdsLocation(resp.Body); err == nil {
-      return getYadisResourceDescriptor(metaContent, getter)
-    } else {
-      return "", "", err
-    }
-  } else if strings.Contains(contentType, "application/xrds+xml") {
-    // 4. A document of MIME media type, application/xrds+xml.
-    if body, err := ioutil.ReadAll(resp.Body); err == nil {
-      return parseXrds(body)
-    } else {
-      return "", "", err
-    }
-  }
-  // 3. HTTP response-headers only, which MAY include an
-  // X-XRDS-Location response-header, a content-type
-  // response-header specifying MIME media type,
-  // application/xrds+xml, or both.
-  //   (this is handled by one of the 2 previous if statements)
-  return "", "", errors.New("No expected header, or content type")
+		if metaContent, err := findMetaXrdsLocation(resp.Body); err == nil {
+			return getYadisResourceDescriptor(metaContent, getter)
+		} else {
+			return "", "", err
+		}
+	} else if strings.Contains(contentType, "application/xrds+xml") {
+		// 4. A document of MIME media type, application/xrds+xml.
+		if body, err := ioutil.ReadAll(resp.Body); err == nil {
+			return parseXrds(body)
+		} else {
+			return "", "", err
+		}
+	}
+	// 3. HTTP response-headers only, which MAY include an
+	// X-XRDS-Location response-header, a content-type
+	// response-header specifying MIME media type,
+	// application/xrds+xml, or both.
+	//   (this is handled by one of the 2 previous if statements)
+	return "", "", errors.New("No expected header, or content type")
 }
 
 // Similar as above, but we expect an absolute Yadis document URL.
 func getYadisResourceDescriptor(id string, getter httpGetter) (opEndpoint string, opLocalId string, err error) {
-  resp, err := getter.Get(id, yadisHeaders)
-  if err != nil {
-    return "", "", err
-  }
-  defer resp.Body.Close()
-  // 4. A document of MIME media type, application/xrds+xml.
-  if body, err := ioutil.ReadAll(resp.Body); err == nil {
-    return parseXrds(body)
-  } else {
-    return "", "", err
-  }
-  return
+	resp, err := getter.Get(id, yadisHeaders)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	// 4. A document of MIME media type, application/xrds+xml.
+	if body, err := ioutil.ReadAll(resp.Body); err == nil {
+		return parseXrds(body)
+	} else {
+		return "", "", err
+	}
+	return
 }
 
 // Search for
 // <head>
 //    <meta http-equiv="X-XRDS-Location" content="....">
 func findMetaXrdsLocation(input io.Reader) (location string, err error) {
-  tokenizer := html.NewTokenizer(input)
-  inHead := false
-  for {
-    tt := tokenizer.Next()
-    switch tt {
-    case html.ErrorToken:
-      return "", tokenizer.Err()
-    case html.StartTagToken, html.EndTagToken:
-      tk := tokenizer.Token()
-      if tk.Data == "head" {
-        if tt == html.StartTagToken {
-          inHead = true
-        } else {
-          return "", errors.New("Meta X-XRDS-Location not found")
-        }
-      } else if inHead && tk.Data == "meta" {
-        ok := false
-        content := ""
-        for _, attr := range tk.Attr {
-          if attr.Key == "http-equiv" &&
-            attr.Val == "X-XRDS-Location" {
-            ok = true
-          } else if attr.Key == "content" {
-            content = attr.Val
-          }
-        }
-        if ok && len(content) > 0 {
-          return content, nil
-        }
-      }
-    }
-  }
-  return "", errors.New("Meta X-XRDS-Location not found")
+	tokenizer := html.NewTokenizer(input)
+	inHead := false
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			return "", tokenizer.Err()
+		case html.StartTagToken, html.EndTagToken:
+			tk := tokenizer.Token()
+			if tk.Data == "head" {
+				if tt == html.StartTagToken {
+					inHead = true
+				} else {
+					return "", errors.New("Meta X-XRDS-Location not found")
+				}
+			} else if inHead && tk.Data == "meta" {
+				ok := false
+				content := ""
+				for _, attr := range tk.Attr {
+					if attr.Key == "http-equiv" &&
+						attr.Val == "X-XRDS-Location" {
+						ok = true
+					} else if attr.Key == "content" {
+						content = attr.Val
+					}
+				}
+				if ok && len(content) > 0 {
+					return content, nil
+				}
+			}
+		}
+	}
+	return "", errors.New("Meta X-XRDS-Location not found")
 }

--- a/src/openid/yadis_discovery_test.go
+++ b/src/openid/yadis_discovery_test.go
@@ -1,17 +1,17 @@
 package openid
 
 import (
-  "bytes"
-  "testing"
+	"bytes"
+	"testing"
 )
 
 func TestFindMetaXrdsLocation(t *testing.T) {
-  searchMeta(t, `
+	searchMeta(t, `
       <html>
         <head>
           <meta http-equiv="X-XRDS-Location" content="foo.com">
       `, "foo.com", false)
-  searchMeta(t, `
+	searchMeta(t, `
       <html>
         <head>
           <meta http-equiv="other" content="blah.com">
@@ -20,11 +20,11 @@ func TestFindMetaXrdsLocation(t *testing.T) {
 }
 
 func TestMetaXrdsLocationOutsideHead(t *testing.T) {
-  searchMeta(t, `
+	searchMeta(t, `
       <html>
         <meta http-equiv="X-XRDS-Location" content="foo.com">
       `, "", true)
-  searchMeta(t, `
+	searchMeta(t, `
       <html>
         <head></head>
         <meta http-equiv="X-XRDS-Location" content="foo.com">
@@ -32,20 +32,20 @@ func TestMetaXrdsLocationOutsideHead(t *testing.T) {
 }
 
 func TestNoMetaXrdsLocation(t *testing.T) {
-  searchMeta(t, `
+	searchMeta(t, `
       <html><head>
         <meta http-equiv="bad-tag" content="foo.com">
       `, "", true)
 }
 
 func searchMeta(t *testing.T, doc, loc string, err bool) {
-  r := bytes.NewReader([]byte(doc))
-  res, e := findMetaXrdsLocation(r)
-  if (e != nil) != err {
-    t.Errorf("Unexpected error: '%s'", e)
-  } else if e == nil {
-    if res != loc {
-      t.Errorf("Found bad location: Expected %s, Got %s", loc, res)
-    }
-  }
+	r := bytes.NewReader([]byte(doc))
+	res, e := findMetaXrdsLocation(r)
+	if (e != nil) != err {
+		t.Errorf("Unexpected error: '%s'", e)
+	} else if e == nil {
+		if res != loc {
+			t.Errorf("Found bad location: Expected %s, Got %s", loc, res)
+		}
+	}
 }

--- a/src/openid_example/server.go
+++ b/src/openid_example/server.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/kushaldas/openid.go/src/openid"
 	"html/template"
 	"log"
 	"net/http"
+
+	"github.com/kushaldas/openid.go/src/openid"
 )
 
 const dataDir = "./"


### PR DESCRIPTION
Use the standard Go formatting. Mechanical change only.
This makes it easier to apply other mechanical changes, such
as rewriting the go.net import paths.
